### PR TITLE
when generating salt, return error if any instead of just logging it

### DIFF
--- a/password_test.go
+++ b/password_test.go
@@ -198,7 +198,8 @@ func TestGenerateSalt(t *testing.T) {
 	// Generate random salts from minSaltSize to maxSaltSize
 	for i := minSaltSize; i < maxSaltSize; i++ {
 		expectedLen := i
-		salt := generateSalt(uint8(expectedLen))
+		salt, err := generateSalt(uint8(expectedLen))
+		assert.NoError(t, err)
 		assert.Len(t, salt, expectedLen)
 	}
 }


### PR DESCRIPTION
Ignoring errors when generating the salt is bad; presently if any errors occurs it will use an empty salt.

I decided not to create a specific error for it because it would mask the original error, and it doesn't seem to be an error that the client could check for and do something about it.

I've also changed the salt generation to the slightly more idiomatic `rand.Read`.